### PR TITLE
CICD-33 | Replaced scheduler and http versions for 1.1.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.mule.services</groupId>
             <artifactId>mule-service-http</artifactId>
-            <version>${mule.api.version}</version>
+            <version>1.1.0</version>
             <classifier>mule-service</classifier>
             <scope>provided</scope>
         </dependency>
@@ -79,7 +79,7 @@
             <groupId>org.mule.services</groupId>
             <artifactId>mule-service-scheduler</artifactId>
             <classifier>mule-service</classifier>
-            <version>${mule.api.version}</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
Replaced scheduler and http versions for 1.1.0.